### PR TITLE
Mention python version in installation requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you are working on the BB5 please run the following commands
 first:
 ```shell
 dvc remote add --local gpfs_proj101 \
-/gpfs/bbp.cscs.ch/data/project/proj101/dvc/remotes/atlas_annotation
+/gpfs/bbp.cscs.ch/data/project/proj101/dvc_remotes/atlas_annotation
 ```
 
 To pull all original data from the remote run


### PR DESCRIPTION
`atlannot` only works with `python3.7`, this PR adds a note about this in the README file, as well as how to get the correct python version on the BB5