### PR TITLE
Fix API docs

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,7 +23,9 @@ jobs:
           pip install -U pip setuptools wheel
           pip install tox
       - name: Static Analysis
-        run: tox -vv -e lint
+        run: tox -e lint
+      - name: Check the API docs
+        run: tox -e apidoc-check
       - name: Test
         run: |
           apt-get update && apt-get install -y libgl1-mesa-dev # Fix cv2 error: https://stackoverflow.com/q/63977422/2804645

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,1 @@
 /_build/
-/source/api/

--- a/docs/source/api/atlannot.ants.rst
+++ b/docs/source/api/atlannot.ants.rst
@@ -1,0 +1,10 @@
+atlannot.ants package
+=====================
+
+Module contents
+---------------
+
+.. automodule:: atlannot.ants
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.atlas.align.rst
+++ b/docs/source/api/atlannot.atlas.align.rst
@@ -1,0 +1,7 @@
+atlannot.atlas.align module
+===========================
+
+.. automodule:: atlannot.atlas.align
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.atlas.merge.rst
+++ b/docs/source/api/atlannot.atlas.merge.rst
@@ -1,0 +1,7 @@
+atlannot.atlas.merge module
+===========================
+
+.. automodule:: atlannot.atlas.merge
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.atlas.region_meta.rst
+++ b/docs/source/api/atlannot.atlas.region_meta.rst
@@ -1,0 +1,7 @@
+atlannot.atlas.region\_meta module
+==================================
+
+.. automodule:: atlannot.atlas.region_meta
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.atlas.rst
+++ b/docs/source/api/atlannot.atlas.rst
@@ -1,0 +1,20 @@
+atlannot.atlas package
+======================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   atlannot.atlas.align
+   atlannot.atlas.merge
+   atlannot.atlas.region_meta
+
+Module contents
+---------------
+
+.. automodule:: atlannot.atlas
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.atlas_merge.JSONread.rst
+++ b/docs/source/api/atlannot.atlas_merge.JSONread.rst
@@ -1,0 +1,7 @@
+atlannot.atlas\_merge.JSONread module
+=====================================
+
+.. automodule:: atlannot.atlas_merge.JSONread
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.atlas_merge.coarse.rst
+++ b/docs/source/api/atlannot.atlas_merge.coarse.rst
@@ -1,0 +1,7 @@
+atlannot.atlas\_merge.coarse module
+===================================
+
+.. automodule:: atlannot.atlas_merge.coarse
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.atlas_merge.fine.rst
+++ b/docs/source/api/atlannot.atlas_merge.fine.rst
@@ -1,0 +1,7 @@
+atlannot.atlas\_merge.fine module
+=================================
+
+.. automodule:: atlannot.atlas_merge.fine
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.atlas_merge.rst
+++ b/docs/source/api/atlannot.atlas_merge.rst
@@ -1,0 +1,20 @@
+atlannot.atlas\_merge package
+=============================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   atlannot.atlas_merge.JSONread
+   atlannot.atlas_merge.coarse
+   atlannot.atlas_merge.fine
+
+Module contents
+---------------
+
+.. automodule:: atlannot.atlas_merge
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.notebook.rst
+++ b/docs/source/api/atlannot.notebook.rst
@@ -1,0 +1,19 @@
+atlannot.notebook package
+=========================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   atlannot.notebook.util
+   atlannot.notebook.volume_viewer
+
+Module contents
+---------------
+
+.. automodule:: atlannot.notebook
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.notebook.util.rst
+++ b/docs/source/api/atlannot.notebook.util.rst
@@ -1,0 +1,7 @@
+atlannot.notebook.util module
+=============================
+
+.. automodule:: atlannot.notebook.util
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.notebook.volume_viewer.rst
+++ b/docs/source/api/atlannot.notebook.volume_viewer.rst
@@ -1,0 +1,7 @@
+atlannot.notebook.volume\_viewer module
+=======================================
+
+.. automodule:: atlannot.notebook.volume_viewer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.rst
+++ b/docs/source/api/atlannot.rst
@@ -1,0 +1,30 @@
+atlannot package
+================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   atlannot.ants
+   atlannot.atlas
+   atlannot.atlas_merge
+   atlannot.notebook
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   atlannot.utils
+   atlannot.version
+
+Module contents
+---------------
+
+.. automodule:: atlannot
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.rst
+++ b/docs/source/api/atlannot.rst
@@ -19,7 +19,6 @@ Submodules
    :maxdepth: 4
 
    atlannot.utils
-   atlannot.version
 
 Module contents
 ---------------

--- a/docs/source/api/atlannot.utils.rst
+++ b/docs/source/api/atlannot.utils.rst
@@ -1,0 +1,7 @@
+atlannot.utils module
+=====================
+
+.. automodule:: atlannot.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.version.rst
+++ b/docs/source/api/atlannot.version.rst
@@ -1,0 +1,7 @@
+atlannot.version module
+=======================
+
+.. automodule:: atlannot.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/atlannot.version.rst
+++ b/docs/source/api/atlannot.version.rst
@@ -1,7 +1,0 @@
-atlannot.version module
-=======================
-
-.. automodule:: atlannot.version
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ skip_install = true
 deps =
     sphinx
 commands =
-    sphinx-apidoc -Tefo docs/source/api src/atlannot
+    sphinx-apidoc -Tefo docs/source/api src/atlannot src/atlannot/version.py
 
 [testenv:apidoc-check]
 skip_install = true
@@ -47,7 +47,7 @@ allowlist_externals = diff
 deps =
     sphinx
 commands =
-    sphinx-apidoc -Tefo {envtmpdir} src/atlannot
+    sphinx-apidoc -Tefo {envtmpdir} src/atlannot src/atlannot/version.py
     diff {envtmpdir} docs/source/api
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,15 @@ deps =
 commands =
     sphinx-apidoc -Tefo docs/source/api src/atlannot
 
+[testenv:apidoc-check]
+skip_install = true
+allowlist_externals = diff
+deps =
+    sphinx
+commands =
+    sphinx-apidoc -Tefo {envtmpdir} src/atlannot
+    diff {envtmpdir} docs/source/api
+
 [flake8]
 max-line-length = 88
 extend-ignore = E203
@@ -70,7 +79,6 @@ setenv =
     SPHINXOPTS = -W
 commands =
     make clean
-    sphinx-apidoc -Tefo source/api ../src/atlannot
     make doctest
     make html
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,13 @@ commands =
     isort --profile=black {[tox]sources}
     black {[tox]sources}
 
+[testenv:apidoc]
+skip_install = true
+deps =
+    sphinx
+commands =
+    sphinx-apidoc -Tefo docs/source/api src/atlannot
+
 [flake8]
 max-line-length = 88
 extend-ignore = E203


### PR DESCRIPTION
* Track the API docs generated by `sphinx-apidoc`
* Add new tox environments:
  * `apidoc`: generate the API docs
  *  `apidoc-check` checked if the API docs are up to date
* Run `apidoc-check` in the CI