### PR TITLE
Expand python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,11 @@ jobs:
       - name: Run linting
         run: tox -e lint
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9]
           include:
             - python-version: 3.7
               tox-env: py37

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.7, 3.8, 3.9]
-          include:
-            - python-version: 3.7
-              tox-env: py37
-            - python-version: 3.8
-              tox-env: py38
-            - python-version: 3.9
-              tox-env: py39
+        include:
+          - python-version: 3.7
+            tox-env: py37
+          - python-version: 3.8
+            tox-env: py38
+          - python-version: 3.9
+            tox-env: py39
     steps:
       - name: Checkout latest commit
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,16 @@ jobs:
         run: tox -e lint
   unit-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ 3.7, 3.8, 3.9 ]
+          include:
+            - python-version: 3.7
+              tox-env: py37
+            - python-version: 3.8
+              tox-env: py38
+            - python-version: 3.9
+              tox-env: py39
     steps:
       - name: Checkout latest commit
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: [3.7, 3.8, 3.9]
           include:
             - python-version: 3.7
@@ -39,12 +39,13 @@ jobs:
         with: {"fetch-depth": 0}  # fetch all history with version tags
       - name: Set up python
         uses: actions/setup-python@v2
-        with: {"python-version": "3.7"}
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Set up pip cache
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: unit-${{ runner.os }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-interactive.txt') }}
+          key: unit-${{ matrix.os }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-interactive.txt') }}
       - name: Set up the environment
         run: |
           # apt-get update && apt-get install ffmpeg libsm6 libxext6 -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
   unit-tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: [3.7, 3.8, 3.9]

--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@ them to CCFv3.
 
 ## Installation
 ### Python Version and Environment
-Note that due to some of our dependencies we're currently limited to python
-version `3.7`. Please make sure you set up a virtual environment with that
-version before trying to install this library. If you're unsure how to do that
-please have a look at [conda](https://docs.conda.io) or
-[pyenv](https://github.com/pyenv/pyenv).
-
 If you are part of the Blue Brain Project and are working on the BB5 you can
 find the correct python version in the archive modules between `archive/2020-02`
 and `archive/2020-12` (inclusive). Here's an example of a set of commands

--- a/README.md
+++ b/README.md
@@ -20,10 +20,16 @@ them to CCFv3.
 
 ## Installation
 ### Python Version and Environment
+The currently python versions supported by `atlannot` package 
+are `3.7`, `3.8`, and `3.9`.
+
 If you are part of the Blue Brain Project and are working on the BB5 you can
-find the correct python version in the archive modules between `archive/2020-02`
-and `archive/2020-12` (inclusive). Here's an example of a set of commands
-that will set up your environment on the BB5:
+find the correct python version in the archive modules:
+- `python3.7`: `archive/2020-02` - `archive/2020-12`
+- `python3.8`: `archive/2021-01` - `archive/2021-12`
+- `python3.9`: `archive/2022-01` - `unstable`.
+  Here's an example of a set of commands that will set up your environment on the BB5:
+
 ```shell
 module purge
 module load archive/2020-12

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ them to CCFv3.
 
 ## Installation
 ### Python Version and Environment
-The currently python versions supported by `atlannot` package 
+The currently supported python versions by `atlannot` package 
 are `3.7`, `3.8`, and `3.9`.
 
 If you are part of the Blue Brain Project and are working on the BB5 you can

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ them to CCFv3.
 
 ## Installation
 ### Python Version and Environment
-The currently supported python versions by `atlannot` package 
-are `3.7`, `3.8`, and `3.9`.
+The currently supported python versions are `3.7`, `3.8`, and `3.9`.
 
 If you are part of the Blue Brain Project and are working on the BB5 you can
 find the correct python version in the archive modules:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,16 +3,15 @@ Installation
 
 Python Version and Environment
 ------------------------------
-Note that due to some of our dependencies we're currently limited to ``python``
-version ``3.7``. Please make sure you set up a virtual environment with that
-version before trying to install this library. If you're unsure how to do that
-please have a look at `conda <https://docs.conda.io>`__ or
-`pyenv <https://github.com/pyenv/pyenv>`__.
+The currently python versions supported by ``atlannot`` package
+are ``3.7``, ``3.8``, and ``3.9``.
 
 If you are part of the Blue Brain Project and are working on the BB5 you can
-find the correct python version in the archive modules between
-``archive/2020-02`` and ``archive/2020-12`` (inclusive). Here's an example of a
-set of commands that will set up your environment on the BB5:
+find the correct python version in the archive modules:
+- ``python3.7``: ``archive/2020-02`` - ``archive/2020-12``
+- ``python3.8``: ``archive/2021-01`` - ``archive/2021-12``
+- ``python3.9``: ``archive/2022-01`` - ``unstable``.
+Here's an example of a set of commands that will set up your environment on the BB5:
 
 .. code-block:: shell
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,8 +3,7 @@ Installation
 
 Python Version and Environment
 ------------------------------
-The currently supported python versions by ``atlannot`` package
-are ``3.7``, ``3.8``, and ``3.9``.
+The currently supported python versions are ``3.7``, ``3.8``, and ``3.9``.
 
 If you are part of the Blue Brain Project and are working on the BB5 you can
 find the correct python version in the archive modules:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Python Version and Environment
 ------------------------------
-The currently python versions supported by ``atlannot`` package
+The currently supported python versions by ``atlannot`` package
 are ``3.7``, ``3.8``, and ``3.9``.
 
 If you are part of the Blue Brain Project and are working on the BB5 you can

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-antspyx==0.2.4
+antspyx==0.3.1
 atldld==0.2.2
 matplotlib==3.3.4
 numpy==1.21.2

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     ],
     package_dir={"": "src"},
     packages=find_packages("src"),
-    python_requires=">=3.7.0",
+    python_requires=">=3.7",
     install_requires=install_requires,
     extras_require=extras_require,
 )

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,8 @@ setup(
         "Operating System :: Unix",
         "Operating System :: MacOS",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     package_dir={"": "src"},
     packages=find_packages("src"),

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 
 install_requires = [
-    "antspyx==0.2.4",
+    "antspyx>=0.2.9",
     "atldld>=0.2.2",
     "matplotlib",
     "numpy",
@@ -80,7 +80,7 @@ setup(
     ],
     package_dir={"": "src"},
     packages=find_packages("src"),
-    python_requires="~=3.7.0",
+    python_requires=">=3.7.0",
     install_requires=install_requires,
     extras_require=extras_require,
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 
 install_requires = [
-    "antspyx>=0.2.9",
+    "antspyx>=0.2.7",
     "atldld>=0.2.2",
     "matplotlib",
     "numpy",

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@
 ; limitations under the License.
 [tox]
 sources = setup.py src/atlannot tests data experiments
-envlist = lint, apidoc-check, py37, docs
+envlist = lint, apidoc-check, py37, py38, py39, docs
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
Fixes #12.

- Extends `Python` Versions `>=3.7.0` (`setup.py` and `CI`)
- Extends `antspyx>=0.2.7`
- Update `README.md`