### PR TITLE
Improve entropy computation

### DIFF
--- a/src/atlannot/evaluation.py
+++ b/src/atlannot/evaluation.py
@@ -183,7 +183,7 @@ def entropy(
 
     Returns
     -------
-    float:
+    float
         Entropy of the (masked) array.
     """
     if ma.isMaskedArray(arr):

--- a/src/atlannot/evaluation.py
+++ b/src/atlannot/evaluation.py
@@ -141,7 +141,7 @@ def iou(
     return scores
 
 
-def dist_entropy(
+def entropy(
     data: np.ndarray,
     bins: int = 100,
 ) -> float:
@@ -185,7 +185,7 @@ def conditional_entropy(
     label_values, count_values = np.unique(atlas[atlas != 0], return_counts=True)
     all_region_entropy = []
     for label, count in zip(label_values, count_values):
-        all_region_entropy.append(dist_entropy(nissl[atlas == label]) * count)
+        all_region_entropy.append(entropy(nissl[atlas == label]) * count)
 
     conditional_entropy = np.sum(all_region_entropy) / n_pixels
     return conditional_entropy
@@ -289,7 +289,7 @@ def evaluate(
         results[name] = evaluate_region(region_ids, atlas, reference, region_meta)
 
     # Entropies
-    brain_entropy = dist_entropy(nissl[atlas != 0])
+    brain_entropy = entropy(nissl[atlas != 0])
     cond_entropy = conditional_entropy(nissl, atlas)
     results["global"] = {
         "brain_entropy": brain_entropy,

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from atlannot.evaluation import (
     conditional_entropy,
-    dist_entropy,
+    entropy,
     evaluate,
     evaluate_region,
     iou,
@@ -61,14 +61,14 @@ def test_compute_iou():
 
 def test_compute_region_entropy():
     volume = np.ones((10, 10, 10))
-    entropy = dist_entropy(volume)
-    assert isinstance(entropy, float)
-    assert entropy == 0
+    entropy_score = entropy(volume)
+    assert isinstance(entropy_score, float)
+    assert entropy_score == 0
 
     nissl = np.random.random((10, 10, 10))
-    entropy = dist_entropy(nissl[volume == 1])
-    assert isinstance(entropy, float)
-    assert entropy > 0
+    entropy_score = entropy(nissl[volume == 1])
+    assert isinstance(entropy_score, float)
+    assert entropy_score > 0
 
 
 def test_compute_conditional_entropy():

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -61,18 +61,6 @@ def test_compute_iou():
     assert np.isnan(scores[11])
 
 
-def test_compute_region_entropy():
-    volume = np.ones((10, 10, 10))
-    entropy_score = entropy(volume)
-    assert isinstance(entropy_score, float)
-    assert entropy_score == 0
-
-    nissl = np.random.random((10, 10, 10))
-    entropy_score = entropy(nissl[volume == 1])
-    assert isinstance(entropy_score, float)
-    assert entropy_score > 0
-
-
 class TestEntropy:
     def test_constant_data(self):
         arr = np.ones((100, 100))

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ envlist = lint, apidoc-check, py37, py38, py39, docs
 skip_install = true
 deps =
     bandit==1.7.0
-    black==21.5b1
+    black==22.3.0
     flake8==3.9.2
     flake8-bugbear==21.4.3
     flake8-comprehensions==3.5.0
@@ -34,7 +34,7 @@ commands =
 [testenv:format]
 skip_install = true
 deps =
-    black==21.5b1
+    black==22.3.0
     isort==5.8.0
 commands =
     isort {posargs:{[tox]sources}}


### PR DESCRIPTION
* Set the default number of bins to 256
* Allow to fix the value range via `value_range`
* Normalize entropy values to `[0, 1]` by setting the log base equal to `n_bins`
* Make sure in `conditional_entropy` the same bins are used for all regions