### PR TITLE
Remove dependence on `atlalign`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,8 @@ with open("README.md", encoding="utf-8") as fh:
 
 install_requires = [
     "antspyx>=0.2.7",
-    "atlalign>=0.6.1",
     "atlas-alignment-meter@git+https://github.com/BlueBrain/atlas-alignment-meter.git",
     "atldld>=0.2.2",
-    # lpips_tf is needed because of atlalign
-    "lpips_tf@git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf",
     "matplotlib",
     "numpy",
     "pynrrd",

--- a/src/atlannot/_atlalign.py
+++ b/src/atlannot/_atlalign.py
@@ -24,7 +24,6 @@ def iou_score_single(
         A class label. If None, then averaging based on label distribution
         in each true image is performed.
 
-
     excluded_labels
         If None then no effect. If a list of ints then the provided labels
         won't be used in the averaging over labels (in case
@@ -89,7 +88,6 @@ def iou_score(
     k
         A class label. If None, then averaging based on label distribution
         in each true image is performed.
-
 
     excluded_labels
         If None then no effect. If a list of ints then the provided labels

--- a/src/atlannot/_atlalign.py
+++ b/src/atlannot/_atlalign.py
@@ -36,7 +36,7 @@ def iou_score_single(
     Returns
     -------
     float
-        result
+        The IOU score
     """
     if k is not None:
         mask_true = y_true == k
@@ -78,4 +78,33 @@ def iou_score(
     k: int | None = 0,
     excluded_labels: list[int] | None = None,
 ):
+    """
+    Compute IOU score for multiple samples.
+
+
+    Parameters
+    ----------
+    y_true
+        A np.ndarray of shape `(N, h, w)` representing the ground truth
+        annotation.
+
+    y_pred
+        A np.ndarray of shape `(N, h, w)` representing the predicted annotation.
+
+    k
+        A class label. If None, then averaging based on label distribution
+        in each true image is performed.
+
+
+    excluded_labels
+        If None then no effect. If a list of ints then the provided labels
+        won't be used in the averaging over labels (in case
+        `k` is None).
+
+    Returns
+    -------
+    float
+        The IOU score
+
+    """
     pass

--- a/src/atlannot/_atlalign.py
+++ b/src/atlannot/_atlalign.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 import numpy as np
 
 
@@ -10,9 +9,7 @@ def iou_score_single(
     k: int | None = None,
     excluded_labels: list[int] | None = None,
 ) -> float:
-    """
-    Compute intersection over union of a class `k`.
-
+    """Compute intersection over union of a class `k`.
 
     Parameters
     ----------
@@ -78,9 +75,7 @@ def iou_score(
     k: int | None = None,
     excluded_labels: list[int] | None = None,
 ) -> tuple[float, np.ndarray]:
-    """
-    Compute IOU score for multiple samples.
-
+    """Compute IOU score for multiple samples.
 
     Parameters
     ----------

--- a/src/atlannot/_atlalign.py
+++ b/src/atlannot/_atlalign.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+
+import numpy as np
+
+def iou_score_single(
+        y_true: np.ndarray,
+        y_pred: np.ndarray,
+        k: int | None = None,
+        excluded_labels: list[int] | None = None,
+    ):
+    """
+    Compute intersection over union of a class `k`.
+    """
+
+    n_pixels = (
+        ~np.isin(y_true, np.array(excluded_labels or []))
+    ).sum()  # only non excluded pixels
+
+    if k is not None:
+        mask_true = y_true == k
+        mask_pred = y_pred == k
+
+        intersection = np.logical_and(mask_true, mask_pred)
+        union = np.logical_or(mask_true, mask_pred)
+
+        res = (
+            (intersection.sum() / union.sum()) if not np.all(union == 0) else np.nan
+        )
+
+    else:
+        # true image distribution
+        w = {
+            label: (y_true == label).sum() / n_pixels
+            for label in (set(np.unique(y_true)) | set(np.unique(y_pred)))
+            - set(excluded_labels or [])
+        }
+
+        weighted_average = sum(
+            iou_score_single(
+                y_true[np.newaxis, :, :],
+                y_pred[np.newaxis, :, :],
+                k,
+            )
+            * p
+            for k, p in w.items()
+        )
+
+        res = weighted_average
+
+    return res
+
+def iou_score(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    k: int | None = 0,
+    excluded_labels: list[int] | None = None,
+    ):
+    pass

--- a/src/atlannot/_atlalign.py
+++ b/src/atlannot/_atlalign.py
@@ -3,20 +3,41 @@ from __future__ import annotations
 
 import numpy as np
 
+
 def iou_score_single(
-        y_true: np.ndarray,
-        y_pred: np.ndarray,
-        k: int | None = None,
-        excluded_labels: list[int] | None = None,
-    ):
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    k: int | None = None,
+    excluded_labels: list[int] | None = None,
+) -> float:
     """
     Compute intersection over union of a class `k`.
+
+
+    Parameters
+    ----------
+    y_true
+        A np.ndarray of shape `(h, w)` representing the ground truth
+        annotation.
+
+    y_pred
+        A np.ndarray of shape `(h, w)` representing the predicted annotation.
+
+    k
+        A class label. If None, then averaging based on label distribution
+        in each true image is performed.
+
+
+    excluded_labels
+        If None then no effect. If a list of ints then the provided labels
+        won't be used in the averaging over labels (in case
+        `k` is None).
+
+    Returns
+    -------
+    float
+        result
     """
-
-    n_pixels = (
-        ~np.isin(y_true, np.array(excluded_labels or []))
-    ).sum()  # only non excluded pixels
-
     if k is not None:
         mask_true = y_true == k
         mask_pred = y_pred == k
@@ -24,22 +45,22 @@ def iou_score_single(
         intersection = np.logical_and(mask_true, mask_pred)
         union = np.logical_or(mask_true, mask_pred)
 
-        res = (
-            (intersection.sum() / union.sum()) if not np.all(union == 0) else np.nan
-        )
+        res = (intersection.sum() / union.sum()) if not np.all(union == 0) else np.nan
 
     else:
+        excluded_labels = excluded_labels or []
+        n_pixels = (~np.isin(y_true, excluded_labels)).sum()
+
         # true image distribution
-        w = {
-            label: (y_true == label).sum() / n_pixels
-            for label in (set(np.unique(y_true)) | set(np.unique(y_pred)))
-            - set(excluded_labels or [])
-        }
+        labels = (set(np.unique(y_true)) | set(np.unique(y_pred))) - set(
+            excluded_labels
+        )
+        w = {label: (y_true == label).sum() / n_pixels for label in labels}
 
         weighted_average = sum(
             iou_score_single(
-                y_true[np.newaxis, :, :],
-                y_pred[np.newaxis, :, :],
+                y_true,
+                y_pred,
                 k,
             )
             * p
@@ -50,10 +71,11 @@ def iou_score_single(
 
     return res
 
+
 def iou_score(
     y_true: np.ndarray,
     y_pred: np.ndarray,
     k: int | None = 0,
     excluded_labels: list[int] | None = None,
-    ):
+):
     pass

--- a/src/atlannot/_atlalign.py
+++ b/src/atlannot/_atlalign.py
@@ -75,9 +75,9 @@ def iou_score_single(
 def iou_score(
     y_true: np.ndarray,
     y_pred: np.ndarray,
-    k: int | None = 0,
+    k: int | None = None,
     excluded_labels: list[int] | None = None,
-):
+) -> tuple[float, np.ndarray]:
     """
     Compute IOU score for multiple samples.
 
@@ -103,8 +103,19 @@ def iou_score(
 
     Returns
     -------
-    float
-        The IOU score
+    iou_average : float
+        Average IOU score
+
+    iou_per_sample : np.ndarray
+        Per sample IOU scores.
 
     """
-    pass
+    n = len(y_true)
+    per_sample = [
+        iou_score_single(y_true[i], y_pred[i], k, excluded_labels) for i in range(n)
+    ]
+
+    per_sample = np.array(per_sample)
+    mean = np.nanmean(per_sample)
+
+    return mean, per_sample

--- a/src/atlannot/_atlalign.py
+++ b/src/atlannot/_atlalign.py
@@ -1,3 +1,16 @@
+# Copyright 2021, Blue Brain Project, EPFL
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from __future__ import annotations
 
 import numpy as np

--- a/src/atlannot/evaluation.py
+++ b/src/atlannot/evaluation.py
@@ -20,12 +20,12 @@ from collections.abc import Collection
 from typing import Any
 
 import numpy as np
-from atlalign.metrics import iou_score
 from atlas_alignment_meter import core
 from numpy import ma
 from scipy import stats
 
 from atlannot.region_meta import RegionMeta
+from atlannot._atlalign import iou_score
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ def iou(
         # and that the region ID is present in both annotation volumes. This
         # can be expensive, so we disable it. If a region ID is not in any of
         # the volumes then the IoU will be NaN.
-        score, _ = iou_score(annot_vol_1, annot_vol_2, k=id_, disable_check=True)
+        score, _ = iou_score(annot_vol_1, annot_vol_2, k=id_)
         scores[id_] = score
 
     return scores

--- a/src/atlannot/evaluation.py
+++ b/src/atlannot/evaluation.py
@@ -24,8 +24,8 @@ from atlas_alignment_meter import core
 from numpy import ma
 from scipy import stats
 
-from atlannot.region_meta import RegionMeta
 from atlannot._atlalign import iou_score
+from atlannot.region_meta import RegionMeta
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_atlalign.py
+++ b/tests/test_atlalign.py
@@ -100,6 +100,30 @@ class TestIOUScoreSingle:
         assert iou_score_single(y_true, y_pred, 1) == 5 / 7
         assert iou_score_single(y_true, y_pred) == 0.5 * 2 / 9 + 5 / 7 * 7 / 9
 
+    def test_exluded_labels(self):
+        y_true = np.array(
+            [
+                [1, 1, 1],
+                [1, 2, 1],
+                [0, 0, 1],
+            ],
+            dtype=np.int8,
+        )
+        y_pred = np.array(
+            [
+                [1, 1, 1],
+                [1, 2, 2],
+                [0, 0, 0],
+            ],
+            dtype=np.int8,
+        )
+        assert iou_score_single(y_true, y_pred, 0) == 2 / 3
+        assert iou_score_single(y_true, y_pred, 1) == 2 / 3
+        assert (
+            iou_score_single(y_true, y_pred, excluded_labels=[2])
+            == 2 / 3 * 2 / 8 + 2 / 3 * 6 / 8
+        )
+
 
 class TestIOUScore:
     pass

--- a/tests/test_atlalign.py
+++ b/tests/test_atlalign.py
@@ -126,4 +126,25 @@ class TestIOUScoreSingle:
 
 
 class TestIOUScore:
-    pass
+    def test_perfect_score_many(self):
+        y_true = np.array(
+            [
+                [
+                    [2, 5, 4],
+                    [2, 2, 1],
+                    [3, 7, 2],
+                ],
+                [
+                    [2, 5, 4],
+                    [2, 2, 1],
+                    [3, 5, 2],
+                ],
+            ],
+            dtype=np.int8,
+        )
+        y_pred = y_true
+
+        mean, per_sample = iou_score(y_true, y_pred)
+
+        assert per_sample.shape == (2,)
+        assert mean == pytest.approx(1, rel=0, abs=1e-10)

--- a/tests/test_atlalign.py
+++ b/tests/test_atlalign.py
@@ -79,6 +79,27 @@ class TestIOUScoreSingle:
         # counts
         assert iou_score_single(y_true, y_pred) != iou_score_single(y_pred, y_true)
 
+    def test_exact_value(self):
+        y_true = np.array(
+            [
+                [1, 1, 1],
+                [1, 1, 1],
+                [0, 0, 1],
+            ],
+            dtype=np.int8,
+        )
+        y_pred = np.array(
+            [
+                [1, 1, 1],
+                [1, 0, 1],
+                [0, 0, 0],
+            ],
+            dtype=np.int8,
+        )
+        assert iou_score_single(y_true, y_pred, 0) == 0.5
+        assert iou_score_single(y_true, y_pred, 1) == 5 / 7
+        assert iou_score_single(y_true, y_pred) == 0.5 * 2 / 9 + 5 / 7 * 7 / 9
+
 
 class TestIOUScore:
     pass

--- a/tests/test_atlalign.py
+++ b/tests/test_atlalign.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+
+
+from atlannot._atlalign import iou_score, iou_score_single
+
+
+class TestIOUScoreSingle:
+    def test_perfect_score(self):
+        y_true = np.array(
+            [
+                [2, 5, 4],
+                [2, 2, 1],
+                [3, 7, 2],
+            ],
+            dtype=np.int8,
+        )
+        y_pred = y_true
+
+        # fixed k
+        assert np.isnan(iou_score_single(y_true, y_pred, 0))  # 0 not present
+        assert iou_score_single(y_true, y_pred, 1) == 1
+        assert iou_score_single(y_true, y_pred, 2) == 1
+        assert iou_score_single(y_true, y_pred, 3) == 1
+        assert iou_score_single(y_true, y_pred, 4) == 1
+        assert iou_score_single(y_true, y_pred, 5) == 1
+        assert np.isnan(iou_score_single(y_true, y_pred, 6))  # 6 not present
+        assert iou_score_single(y_true, y_pred, 7) == 1
+
+        # average over all k's
+        assert iou_score_single(y_true, y_pred) == pytest.approx(1, rel=0, abs=1e-10)
+
+    def test_worst_score(self):
+        y_true = np.array(
+            [
+                [1, 0, 1],
+                [1, 1, 1],
+                [0, 0, 1],
+            ],
+            dtype=np.int8,
+        )
+        y_pred = 1 - y_true
+
+        # fixed k
+        assert iou_score_single(y_true, y_pred, 0) == 0
+        assert iou_score_single(y_true, y_pred, 1) == 0
+        assert np.isnan(iou_score_single(y_true, y_pred, 2))  # 2 not present
+
+        # average over all k's
+        assert iou_score_single(y_true, y_pred) == pytest.approx(0, rel=0, abs=1e-10)
+
+
+class TestIOUScore:
+    pass

--- a/tests/test_atlalign.py
+++ b/tests/test_atlalign.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-
 from atlannot._atlalign import iou_score, iou_score_single
 
 

--- a/tests/test_atlalign.py
+++ b/tests/test_atlalign.py
@@ -49,6 +49,36 @@ class TestIOUScoreSingle:
         # average over all k's
         assert iou_score_single(y_true, y_pred) == pytest.approx(0, rel=0, abs=1e-10)
 
+    def test_symmetric(self):
+        y_true = np.array(
+            [
+                [1, 0, 1],
+                [1, 1, 1],
+                [0, 0, 1],
+            ],
+            dtype=np.int8,
+        )
+        y_pred = np.array(
+            [
+                [1, 0, 0],
+                [1, 0, 1],
+                [0, 1, 1],
+            ],
+            dtype=np.int8,
+        )
+
+        # fixed k
+        assert iou_score_single(y_true, y_pred, 0) == iou_score_single(
+            y_pred, y_true, 0
+        )
+        assert iou_score_single(y_true, y_pred, 1) == iou_score_single(
+            y_pred, y_true, 1
+        )
+
+        # average over all k's - not symmetric since 0's and 1's have different
+        # counts
+        assert iou_score_single(y_true, y_pred) != iou_score_single(y_pred, y_true)
+
 
 class TestIOUScore:
     pass

--- a/tests/test_atlalign.py
+++ b/tests/test_atlalign.py
@@ -1,3 +1,16 @@
+# Copyright 2021, Blue Brain Project, EPFL
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import numpy as np
 import pytest
 


### PR DESCRIPTION
Closes #41 

I refactored the implementation  of `iou_score` and also wrote custom tests.

The main "API" change is that the `disable_check` parameter is not present anymore (no checks are run).