### PR TITLE
Remove `atlas_alignment_meter` from `setup.py`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r requirements-interactive.txt
-          pip install ".[interactive,metrics]"
+          pip install ".[interactive]"
+          pip install git+https://github.com/BlueBrain/atlas-alignment-meter.git
       - name: Run unit tests
         run: pytest --color=yes --durations=5 -v -m "" --cov
   docs:

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,6 @@ extras_require = {
         "toml",
         "tqdm",
     ],
-    "metrics": [
-        "atlas-alignment-meter@git+https://github.com/BlueBrain/atlas-alignment-meter.git",  # noqa: E501
-    ],
 }
 
 setup(


### PR DESCRIPTION
Trying to address following issue when pushing package on PyPI:

```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/                                                                                                                                                              
         Invalid value for requires_dist. Error: Can't have direct dependency: "atlas-alignment-meter @ git+https://github.com/BlueBrain/atlas-alignment-meter.git ; extra == 'metrics'" 
```